### PR TITLE
fix: use --filename-override for correct .sops.yaml rule matching

### DIFF
--- a/jetbrains/src/main/kotlin/com/sopsie/execution/SopsRunner.kt
+++ b/jetbrains/src/main/kotlin/com/sopsie/execution/SopsRunner.kt
@@ -115,8 +115,11 @@ class SopsRunner {
             // Write content to temp file
             tempFile.writeText(content, Charsets.UTF_8)
 
-            // Encrypt the temp file
-            return runSops(listOf("--encrypt", tempFile.absolutePath), tempFile.absolutePath)
+            // Encrypt the temp file, using --filename-override to ensure SOPS matches rules against the original path
+            return runSops(
+                listOf("--encrypt", "--filename-override", filePath, tempFile.absolutePath),
+                tempFile.absolutePath
+            )
         } finally {
             // Always clean up temp file
             try {

--- a/vscode/src/sops/sopsRunner.ts
+++ b/vscode/src/sops/sopsRunner.ts
@@ -83,8 +83,11 @@ export class SopsRunner {
             // Write content to temp file
             fs.writeFileSync(tempFilePath, content, 'utf8');
 
-            // Encrypt the temp file
-            const result = await this.runSops(['--encrypt', tempFilePath], tempFilePath);
+            // Encrypt the temp file, using --filename-override to ensure SOPS matches rules against the original path
+            const result = await this.runSops(
+                ['--encrypt', '--filename-override', filePath, tempFilePath],
+                tempFilePath
+            );
 
             return result;
         } finally {


### PR DESCRIPTION
When encrypting content via temp files, SOPS was using the temp file's path for rule matching in .sops.yaml. This caused "no matching creation rules found" errors when rules used filename_regex or specific path_regex patterns that expected the original filename.

Pass --filename-override with the original file path so SOPS matches rules correctly regardless of the temp file's actual name.

Fixes #1